### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch'
+        required: true
+        default: 'master'
+      tag:
+        description: 'Release Tag'
+        required: true
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+
+      - name: Build Cross
+        run: make cross
+        
+      - name: Ship it
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          prerelease: true
+          tag: ${{ github.event.inputs.tag }}
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A manual github action to run a pre-release

Exemple of the result:
https://github.com/glours/urlgrab/runs/885625096?check_suite_focus=true

And the draft release with the 3 artifacts
https://github.com/glours/urlgrab/releases/tag/untagged-4f33e1b2dc13df78ad38

<img width="1395" alt="Screen Shot 2020-07-18 at 10 52 07 PM" src="https://user-images.githubusercontent.com/705411/87861767-8aff3c80-c949-11ea-982b-84d05282050a.png">



⚠️ the workflow should be in the main branch to be available!